### PR TITLE
Add unit test for LoginController

### DIFF
--- a/src/test/java/com/example/demo/LoginControllerUnitTest.java
+++ b/src/test/java/com/example/demo/LoginControllerUnitTest.java
@@ -1,0 +1,41 @@
+package com.example.demo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class LoginControllerUnitTest {
+
+    @InjectMocks
+    private LoginController loginController;
+
+    @Test
+    void loginSuccess() {
+        LoginController.LoginRequest request = new LoginController.LoginRequest();
+        request.username = "admin";
+        request.password = "password";
+
+        ResponseEntity<String> response = loginController.login(request);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Login successful", response.getBody());
+    }
+
+    @Test
+    void loginFail() {
+        LoginController.LoginRequest request = new LoginController.LoginRequest();
+        request.username = "admin";
+        request.password = "wrong";
+
+        ResponseEntity<String> response = loginController.login(request);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertEquals("Unauthorized", response.getBody());
+    }
+}


### PR DESCRIPTION
## Summary
- add a pure unit test for `LoginController` using JUnit 5 and Mockito

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685125ab4f3c8320aad96c8604b61792